### PR TITLE
fix: use `cl-defun` instead of `defun*`

### DIFF
--- a/unicode-escape.el
+++ b/unicode-escape.el
@@ -80,7 +80,7 @@
   (cl-labels ((escape (c) (-escape-char c surrogate)))
     (apply #'concat (mapcar #'escape (vconcat sequence)))))
 
-(defun* -escape-object (obj &optional (surrogate t))
+(cl-defun -escape-object (obj &optional (surrogate t))
   "Escape unicode characters to \\uNNNN notation in OBJ (character or string).
 If SURROGATE is non-nil, non-BMP characters (U+10000..U+10FFFF)
 convert to surrogate pairs."
@@ -127,7 +127,7 @@ non-BMP characters is escaped \\UNNNNNNNN."
            nil
            (-parse-escaped-string notations))))
 
-(defun* -unescape-string (string &optional (surrogate t))
+(cl-defun -unescape-string (string &optional (surrogate t))
   "Unescape unicode notations \\uNNNN and \\UNNNNNNNN in STRING.
 If SURROGATE is non-nil, surrogate pairs convert to original code point."
   (let ((case-fold-search nil))


### PR DESCRIPTION
Emacs always complains `(void-function defun*)` when start with `--debug-init`.
![image](https://user-images.githubusercontent.com/32241529/206351210-65489d5a-aa02-4444-82cb-de71a2065cc6.png)
And there is no alias definition.
![image](https://user-images.githubusercontent.com/32241529/206351397-96d28fb1-876c-449e-b15b-71663a2cd775.png)
