### PR TITLE
Update unicode-escape.el

### DIFF
--- a/unicode-escape.el
+++ b/unicode-escape.el
@@ -127,7 +127,7 @@ non-BMP characters is escaped \\UNNNNNNNN."
            nil
            (-parse-escaped-string notations))))
 
-(defun* -unescape-string (string &optional (surrogate t))
+(cl-defun -unescape-string (string &optional (surrogate t))
   "Unescape unicode notations \\uNNNN and \\UNNNNNNNN in STRING.
 If SURROGATE is non-nil, surrogate pairs convert to original code point."
   (let ((case-fold-search nil))


### PR DESCRIPTION
`defun*`  is an obsolete alias (as of 27.1); 
use `cl-defun`  instead.

otherwise
Error loading autoloads: (void-function `defun*` )